### PR TITLE
Eth data validation

### DIFF
--- a/Contributions/Code - Proof_Of_Contribution.md
+++ b/Contributions/Code - Proof_Of_Contribution.md
@@ -168,3 +168,4 @@ You need a wallet like Metamask that can receive Ethereum based tokens. MOR is a
 | 0x0d2065e3Ed3E36919b2AD12FDA8E428Da91bb28D | https://dune.com/potato6969/morpheus-fair-launch and [https://github.com/MorpheusAIs/Morpheus/pull/587](https://github.com/MorpheusAIs/Morpheus/pull/587) | 20 | Dune Dashboard and Guide for TCM Contracts Data Analysis |
 | 0x28D3bDeCE9A0c7F54687F734fA73fBA04ECf5785 | https://github.com/MorpheusAIs/Morpheus/pull/569 | 8 Hours | Translated Yellowpaper into Korean |
 | 0xA94b40c53432f0576E64873CE1CEAd1aae62Fc90 |  | 10 Hours | Best Practice #7 |
+| 0x039Cd33FA67d0aEc5a406598E045F084bb42f7D5 | TBC | 6 Hours | LLM JSON Validator 1.0 - created TransactionParams, updates to TransactionRequest etc.

--- a/src/agent/metamask-agent/backend/main.py
+++ b/src/agent/metamask-agent/backend/main.py
@@ -4,8 +4,8 @@ from utils.functions import convert_to_messages
 #from agents.metamask import rag_chain
 from agents.metamask2 import MOR_prompt, llm
 import re
-import json
-from pydantic import BaseModel
+#import json
+from pydantic import ValidationError
 from fastapi.middleware.cors import CORSMiddleware
 
 ##api endpoints
@@ -54,7 +54,7 @@ async def prompt_model(
     #regular expression to find json
     json_str = re.search(r'({.*})', ai_msg, re.DOTALL)
 
-    data = {}
+    # data = {}
     txConfirmed = False #TODO:set this with secondary model to check confirmation - run concurrently w user prompt
     if json_str:
         json_data = json_str.group(1)
@@ -63,11 +63,11 @@ async def prompt_model(
         json_data = re.sub(r'//.*?\n', '', json_data)
         
         try:
-            # Convert JSON string to Python dictionary
-            data = json.loads(json_data)
+            # Parse the data into JSON format using Pydantic's parse_raw method
+            data = TransactionRequest.parse_raw(json_data)
             txConfirmed = True
             print(data)
-        except json.JSONDecodeError as e:
+        except ValidationError as e:
             print(f"Error decoding JSON: {e}")
     else:
         print("No JSON found")

--- a/src/agent/metamask-agent/backend/utils/models.py
+++ b/src/agent/metamask-agent/backend/utils/models.py
@@ -1,8 +1,28 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
+
+#Metamask Dictionary of supported methods (for use in Morpheus AI)
+TransactionMethods = {
+    "eth_sendTransaction": "Ethereum transaction",
+    # Add more methods over time
+}
+
+# Class validator to check returned JSON from LLM is consistent with Metamask Requirements
+class TransactionParams(BaseModel):
+    from_: str = Field(..., pattern=r"^0x[a-fA-F0-9]{40}$", alias="from") 
+    to: str = Field(..., pattern=r"^0x[a-fA-F0-9]{40}$")
+    gas: str = Field(..., pattern=r"^0x([1-9a-f]+[0-9a-f]*|0)$")
+    gasPrice: str = Field(..., pattern=r"^0x([1-9a-f]+[0-9a-f]*|0)$")
+    value: str = Field(..., pattern=r"^0x([1-9a-f]+[0-9a-f]*|0)$")
+    data: str = Field(..., pattern=r"^0x[0-9a-f]*$") 
 
 class TransactionRequest(BaseModel):
     method: str
-    params: list[dict] 
+    params: list[TransactionParams] 
+    @field_validator('method')
+    def supported_methods(cls, method):
+        if method not in TransactionMethods:
+            raise ValueError(f"Morpheus currently supports the following methods: {list(TransactionMethods.keys())}")
+        return method
 
 class EthSendTransactionParams(BaseModel):
     from_: str


### PR DESCRIPTION
The current Metamask model logic assumes that the LLM JSON response is correct to initiate Metamask transactions.  
Data validation is necessary to ensure that the LLM JSON response is correct and valid, because:
1. Base-model training is done up to a set date i.e. they may not have seen the latest updates to Metamask (or other API specs) and could return methods, format etc. that is no longer supported
2. Base-model hallucinations can cause a high confidence response of incorrect data. 

The following PR is a proposed solution that builds on our existing logic with minimal changes to code base: These include:
- [ ] TransactionParams: Created a new class called TransactionParams that checks the validity of the JSON response from LLM against Metamask specs
- [ ] TransactionRequest: Updated TransactionRequest class to incorporate TransactionParams. Also updated TransactionRequest to validate the method response from LLM is a valid Metamask method (and one that Morpheus wants to support) by adding a field_validator to check TransactionMethods dict
- [ ] TransactionMethods: Created a dictionary of supported Metamask Transaction methods. This also allows us to control the functionality we want to offer users as we test and scale LLM performance/capabilities.